### PR TITLE
Use upper case 'B' for B natural midi, not 'b'

### DIFF
--- a/desktop/core/lib/_midi.js
+++ b/desktop/core/lib/_midi.js
@@ -18,7 +18,7 @@ function FnMidi (pico, x, y, passive) {
 
     this.draw = false
 
-    const notes = ['C', 'c', 'D', 'd', 'E', 'F', 'f', 'G', 'g', 'A', 'a', 'b']
+    const notes = ['C', 'c', 'D', 'd', 'E', 'F', 'f', 'G', 'g', 'A', 'a', 'B']
     const channel = clamp(this.listen(this.ports.input.channel, true), 0, 15)
     const octave = clamp(this.listen(this.ports.input.octave, true), 2, 9)
     const note = this.listen(this.ports.input.note)


### PR DESCRIPTION
A tiny bugfix so that B natural is handled like I expected, from the README's explanation of sharps and how E natural works.

This is a fascinating little machine, thank you for sharing :pray: 