### PR TITLE
initial work on using tonejs as a default output if no midi ports 

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -24,6 +24,7 @@
     "electron-rebuild": "^1.8.2"
   },
   "dependencies": {
-    "node-osc": "^3.0.0"
+    "node-osc": "^3.0.0",
+    "tone": "^13.4.9"
   }
 }


### PR DESCRIPTION
I have done some initial work on using [tonejs](https://tonejs.github.io) as a sound engine when there are no midi ports. I believe this will give the following advantages

1) Users testing the waters using Orca will hear results faster if they don't have midi hardware or other software synths setup
2) Tonejs is very flexible. I plan on doing some more work to let people configure the synth, and also have different synths on each channel.
3) It would be amazing to have a second tab that was a grid editor that let people create midi channels inputs, with synths config, jumpers/yumpers and effect nodes, etc. 

Anyway, this is initial work down this idea. 