### PR TITLE
Fix Electron compatibility

### DIFF
--- a/desktop/sources/scripts/core/io/midi.js
+++ b/desktop/sources/scripts/core/io/midi.js
@@ -185,7 +185,7 @@ function Midi (client) {
 
   this.refresh = function () {
     if (!navigator.requestMIDIAccess) { return }
-    navigator.requestMIDIAccess().then(this.access, (err) => {
+    navigator.requestMIDIAccess({ sysex: false }).then(this.access, (err) => {
       console.warn('No Midi', err)
     })
   }

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       })
 
       // Register PWA Service Worker
-      if (location.protocol.substr(0,4) !== ('file') && 'serviceWorker' in navigator) {
+      if (location.protocol === 'https:' && 'serviceWorker' in navigator) {
         try { navigator.serviceWorker.register('sw.js') } catch (err) { console.warn(err) }
       }
     </script>


### PR DESCRIPTION
- Request MIDI access with explicit {sysex: false} to suppress deprecation warning since Chrome M77
- Restrict service worker registration to https: only (app:// and file:// are not supported)